### PR TITLE
Make parser more robust

### DIFF
--- a/aJSON.h
+++ b/aJSON.h
@@ -28,6 +28,7 @@
 #include <Print.h>
 #include <Stream.h>
 #include <Client.h>
+#include <Arduino.h>  // To get access to the Arduino millis() function
 
 /******************************************************************************
  * Definitions
@@ -87,6 +88,7 @@ public:
 	int printString(aJsonObject *item);
 
 	int skip();
+	int flush();
 
 	int parseValue(aJsonObject *item, char** filter);
 	int printValue(aJsonObject *item);


### PR DESCRIPTION
The original parser does not cope gracefully with input that is
not proper json. Try sending "Hi there" to any of the library
examples and see the results.

This commit adds two things:
- the "getch" method in aJsonStream now times out after 500ms.
  This removes the situation whereby the parser got often stuck
  waiting forever on malformed input.
- A new "flush" method is added, because the parser leaves the
  input buffer untouched in case it cannot understand the contents,
  which means that it will get stuck forever again trying to parse
  the same input if we try several times.

Let me know what you think, it works nicely in my situation, so I though
I would share.
