### PR TITLE
Fix aJsonClientStream to work with WiFiClient too

### DIFF
--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -125,7 +125,7 @@ aJsonClientStream::getch()
       return ret;
     }
   while (!stream()->available() && stream()->connected()) /* spin */;
-  if (!stream()->connected())
+  if (!stream()->available()) // therefore, !stream()->connected()
     {
       stream()->stop();
       return EOF;


### PR DESCRIPTION
EthernetClient will stay connected() as long as data is available(),
but WiFiClient() can switch to !connected() while there are still data
unread in its buffer and therefore available(). Therefore, let's check
for available() when reading data rather than connected().
