### PR TITLE
fix comments about type for numerical values

### DIFF
--- a/aJSON.h
+++ b/aJSON.h
@@ -60,8 +60,8 @@ typedef struct aJsonObject {
 	union {
 		char *valuestring; // The item's string, if type==aJson_String
 		char valuebool; //the items value for true & false
-		int valueint; // The item's number, if type==aJson_Number
-		double valuefloat; // The item's number, if type==aJson_Number
+		int valueint; // The item's value, if type==aJson_Int
+		double valuefloat; // The item's value, if type==aJson_Float
 	};
 } aJsonObject;
 


### PR DESCRIPTION
The comments for valueint and valuefloat refer to an invalid type enum. Updated comments to refer to valid enum values.
