### PR TITLE
Fix pgmspace include for Teensyduino

### DIFF
--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -36,7 +36,7 @@
 #include <stdlib.h>
 #include <float.h>
 #include <ctype.h>
-#ifdef __AVR__
+#if defined(__AVR__) || defined(TEENSYDUINO)
 #include <avr/pgmspace.h>
 #else
 #include <pgmspace.h>


### PR DESCRIPTION
Teensyduino puts pgmspace.h in the avr directory even though the Teensy 3.0 and later is not really an AVR, so I added an additional check for the TEENSYDUINO define to fix it.
