### PR TITLE
adding class "aJsonFileStream" inherited from aJsonStream in order to backward- compatibility with HTTPClient library

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
   Copyright (c) 2010, Interactive Matter, Marcus Nowotny
 
   Based on the cJSON Library, Copyright (C) 2009 Dave Gamble
+  Updated by anklimov - changelog on the bottom of readme
 
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to deal
@@ -295,3 +296,61 @@ As soon as you call aJson.print(), it renders the structure to text.
 
 
 Have Fun!
+
+New in this fork:
+adding class "aJsonFileStream" inherited from aJsonStream in order to backward- compatibility with HTTPClient library
+Now is possible to operate directly with *FILE like streams, returned by HttpClient library and avoid intermediate buffering
+
+Code example:
+
+
+int getConfig()
+{
+    FILE* result;
+    int returnCode ;
+
+    HTTPClient hclient("192.168.88.2",hserver,80);
+    result = hclient.getURI( FEED_URI);
+    returnCode = hclient.getLastReturnCode();
+
+    if (result!=NULL) {
+      if (returnCode==200) {
+
+          Serial.println("got Config :"); 
+             aJsonFileStream as=aJsonFileStream(result);  
+          root = aJson.parse(&as);
+
+     hclient.closeStream(result);  // this is very important -- be sure to close the STREAM
+
+        if (!root)
+          {
+            Serial.println("parseObject() failed");
+           return -11;
+            } else   
+
+          {
+
+            char * outstr=aJson.print(root);
+            Serial.println(outstr);
+             items = aJson.getObjectItem(root,"items");            
+          }
+
+            } 
+    else {
+      Serial.print("ERROR: Server returned ");
+      Serial.println(returnCode);
+      return -11;
+
+    }
+
+    } 
+    else {
+      Serial.println("failed to connect");
+      Serial.println(" try again in 5 seconds");
+      return -11;
+                }
+
+
+
+  return 2;
+}

--- a/README.md
+++ b/README.md
@@ -349,8 +349,5 @@ int getConfig()
       Serial.println(" try again in 5 seconds");
       return -11;
                 }
-
-
-
   return 2;
 }

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -264,6 +264,7 @@ aJsonStream::parseNumber(aJsonObject *item)
     {
       item->valueint = i * (int) sign;
       item->type = aJson_Int;
+      item->subtype = 0;
     }
   //ok it seems to be a double
   else
@@ -306,6 +307,7 @@ aJsonStream::parseNumber(aJsonObject *item)
 
       item->valuefloat = n;
       item->type = aJson_Float;
+      item->subtype = 0;
     }
   //preserve the last character for the next routine
   this->ungetch(in);
@@ -371,6 +373,7 @@ aJsonStream::parseString(aJsonObject *item)
       return EOF; // not a string!
     }
   item->type = aJson_String;
+  item->subtype = 0;
   //allocate a buffer & track how long it is and how much we have read
   string_buffer* buffer = stringBufferCreate();
   if (buffer == NULL)
@@ -646,6 +649,7 @@ aJsonStream::parseValue(aJsonObject *item, char** filter)
       if (!strncmp(buffer, "null", 4))
         {
           item->type = aJson_NULL;
+          item->subtype = 0;
           return 0;
         }
       else
@@ -665,6 +669,7 @@ aJsonStream::parseValue(aJsonObject *item, char** filter)
       if (!strncmp(buffer, "false", 5))
         {
           item->type = aJson_Boolean;
+          item->subtype = 0;
           item->valuebool = false;
           return 0;
         }
@@ -681,6 +686,7 @@ aJsonStream::parseValue(aJsonObject *item, char** filter)
       if (!strncmp(buffer, "true", 4))
         {
           item->type = aJson_Boolean;
+          item->subtype = 0;
           item->valuebool = true;
           return 0;
         }
@@ -742,6 +748,7 @@ aJsonStream::parseArray(aJsonObject *item, char** filter)
     }
 
   item->type = aJson_Array;
+  item->subtype = 0;
   this->skip();
   in = this->getch();
   //check for empty array
@@ -836,6 +843,7 @@ aJsonStream::parseObject(aJsonObject *item, char** filter)
     }
 
   item->type = aJson_Object;
+  item->subtype = 0;
   this->skip();
   //check for an empty object
   in = this->getch();
@@ -1122,6 +1130,7 @@ aJsonClass::createNull()
   aJsonObject *item = newItem();
   if (item)
     item->type = aJson_NULL;
+    item->subtype = 0;
   return item;
 }
 
@@ -1131,6 +1140,7 @@ aJsonClass::createItem(bool b)
   aJsonObject *item = newItem();
   if (item){
     item->type = aJson_Boolean;
+    item->subtype = 0;
     item->valuebool = b;
   }
     
@@ -1144,6 +1154,7 @@ aJsonClass::createItem(char b)
   if (item)
     {
       item->type = aJson_Boolean;
+      item->subtype = 0;
       item->valuebool = b ? -1 : 0;
     }
   return item;
@@ -1156,6 +1167,7 @@ aJsonClass::createItem(long int num)
   if (item)
     {
       item->type = aJson_Int;
+      item->subtype = 0;
       item->valueint = (long int) num;
     }
   return item;
@@ -1168,6 +1180,7 @@ aJsonClass::createItem(double num)
   if (item)
     {
       item->type = aJson_Float;
+      item->subtype = 0;
       item->valuefloat = num;
     }
   return item;
@@ -1180,6 +1193,7 @@ aJsonClass::createItem(const char *string)
   if (item)
     {
       item->type = aJson_String;
+      item->subtype = 0;
      /// item->valuestring = strdup(string);
      item->valuestring = newString(string);
     }
@@ -1192,6 +1206,7 @@ aJsonClass::createArray()
   aJsonObject *item = newItem();
   if (item)
     item->type = aJson_Array;
+    item->subtype = 0;
   return item;
 }
 aJsonObject*
@@ -1200,6 +1215,7 @@ aJsonClass::createObject()
   aJsonObject *item = newItem();
   if (item)
     item->type = aJson_Object;
+    item->subtype = 0;
   return item;
 }
 

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -43,6 +43,7 @@
 #endif
 #include "aJSON.h"
 #include "utility/stringbuffer.h"
+#include <stdio.h>
 
 /******************************************************************************
  * Definitions
@@ -81,6 +82,7 @@ aJsonStream::getch()
       bucket = EOF;
       return ret;
     }
+
   // In case input was malformed - can happen, this is the
   // real world, we can end up in a situation where the parser
   // would expect another character and end up stuck on
@@ -95,6 +97,22 @@ aJsonStream::ungetch(char ch)
 {
   bucket = ch;
 }
+
+
+int
+aJsonFileStream::getch()
+{
+  if (bucket != EOF)
+    {
+      int ret = bucket;
+      bucket = EOF;
+      return ret;
+    }
+  return fgetc(fl);
+}
+
+
+
 
 size_t
 aJsonStream::write(uint8_t ch)

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -49,9 +49,11 @@
 #if defined(__SAM3X8E__)
 #include <DueFlashStorage.h>
 extern DueFlashStorage EEPROM;
-#elif defined(NRF5)
+#elif defined(NRF5) || defined (ARDUINO_ARCH_ESP32)
 #include <NRFFlashStorage.h>
 extern NRFFlashStorage EEPROM;
+#elif defined(ARDUINO_ARCH_ESP8266)
+#include <ESP_EEPROM.h>
 #else
 #include <EEPROM.h>
 #endif
@@ -142,7 +144,7 @@ aJsonEEPROMStream::available()
   if (bucket != EOF)
     return true;
 
-#if defined(__SAM3X8E__) or defined(ARDUINO_ARCH_STM32F1) or defined (NRF5)
+#if defined(__SAM3X8E__) or defined(ARDUINO_ARCH_STM32F1) or defined (NRF5) or defined (ARDUINO_ARCH_ESP32)
   while ((ch!=EOF) && (offset<32000))  ///fix it
 #else
   while (addr+offset<EEPROM.length())
@@ -169,6 +171,17 @@ EEPROM.write(addr+offset++,(char)ch);
 return 1;
 }
 
+int aJsonEEPROMStream::putEOF(void)
+       {
+       int res;
+       res = write(EOF);
+       #if defined(ARDUINO_ARCH_ESP8266)
+         // write the data to EEPROM
+       res  = EEPROM.commit();
+       #endif.
+       //Serial.println((res) ? "Commit OK" : "Commit failed");
+       return res;
+       }
 
 size_t
 aJsonStream::write(uint8_t ch)

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -36,17 +36,19 @@
 #include <stdlib.h>
 #include <float.h>
 #include <ctype.h>
-#ifdef __AVR__
+#ifdef __AVR__ 
 #include <avr/pgmspace.h>
+#elif defined(__arm__) 
+#include <sam/pgmspace.h>
 #else
-//#include <pgmspace.h>
+#include <pgmspace.h>
 #endif
 #include "aJSON.h"
 #include "utility/stringbuffer.h"
 #include <stdio.h>
 #if defined(__SAM3X8E__)
 #include <DueFlashStorage.h>
-DueFlashStorage EEPROM;
+extern DueFlashStorage EEPROM;
 #else
 #include <EEPROM.h>
 #endif
@@ -133,16 +135,19 @@ aJsonEEPROMStream::getch()
 bool
 aJsonEEPROMStream::available()
 {
+  int ch =0;
   if (bucket != EOF)
     return true;
+
 #if defined(__SAM3X8E__)
-  while (1)  ///fix it
+  while ((ch!=EOF) && (offset<32000))  ///fix it
 #else
   while (addr+offset<EEPROM.length())
 #endif    
+
     {
       /* Make an effort to skip whitespace. */
-      int ch = this->getch();
+      ch = this->getch();
       
       if (ch > 32)
        {
@@ -157,17 +162,8 @@ aJsonEEPROMStream::available()
 size_t
 aJsonEEPROMStream::write(uint8_t ch)
 {
-#if defined(__SAM3X8E__)
-  while (1)  ///fix it
-#else
-  while (addr+offset<EEPROM.length())
-#endif
-
-    {
-      return 0;
-    }
 EEPROM.write(addr+offset++,(char)ch);
-  return 1;
+return 1;
 }
 
 

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -54,7 +54,7 @@
 #define BUFFER_DEFAULT_SIZE 4
 
 //how much digits after . for float
-#define FLOAT_PRECISION 1
+#define FLOAT_PRECISION 2
 
 
 bool

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -300,7 +300,7 @@ aJsonClass::deleteItem(aJsonObject *c)
 int
 aJsonStream::parseNumber(aJsonObject *item)
 {
-  int i = 0;
+  long int i = 0;
   int sign = 1;
 
   int in = this->getch();
@@ -1206,13 +1206,13 @@ aJsonClass::createItem(char b)
 }
 
 aJsonObject*
-aJsonClass::createItem(int num)
+aJsonClass::createItem(long int num)
 {
   aJsonObject *item = newItem();
   if (item)
     {
       item->type = aJson_Int;
-      item->valueint = (int) num;
+      item->valueint = (long int) num;
     }
   return item;
 }
@@ -1260,7 +1260,7 @@ aJsonClass::createObject()
 
 // Create Arrays:
 aJsonObject*
-aJsonClass::createIntArray(int *numbers, unsigned char count)
+aJsonClass::createIntArray(long int *numbers, unsigned char count)
 {
   unsigned char i;
   aJsonObject *n = 0, *p = 0, *a = createArray();
@@ -1340,7 +1340,7 @@ aJsonClass::addBooleanToObject(aJsonObject* object, const char* name, bool b)
 }
 
 void
-aJsonClass::addNumberToObject(aJsonObject* object, const char* name, int n)
+aJsonClass::addNumberToObject(aJsonObject* object, const char* name, long int n)
 {
   addItemToObject(object, name, createItem(n));
 }

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -511,13 +511,14 @@ aJsonStream::printString(aJsonObject *item)
 // Utility to jump whitespace and cr/lf
 int
 aJsonStream::skip()
-{
+{ 
+  int skipCounter=256;
   int in = this->getch();
-  while (in != EOF && (in <= 32))
+  while (in != EOF && (in <= 32) && skipCounter--)
     {
       in = this->getch();
     }
-  if (in != EOF)
+  if ((in != EOF) && skipCounter)
     {
       this->ungetch(in);
       return 0;
@@ -566,11 +567,15 @@ aJsonClass::parse(aJsonStream* stream, char** filter)
     }
   aJsonObject *c = newItem();
   if (!c)
+    {
+    //debugPrint("new item fail\n");   
     return NULL; /* memory fail */
+    }
 
   stream->skip();
   if (stream->parseValue(c, filter) == EOF)
     {
+      //debugPrint("del item\n"); 
       deleteItem(c);
       return NULL;
     }

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -52,7 +52,7 @@
 #define BUFFER_DEFAULT_SIZE 4
 
 //how much digits after . for float
-#define FLOAT_PRECISION 5
+#define FLOAT_PRECISION 1
 
 
 bool

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -139,7 +139,7 @@ aJsonEEPROMStream::available()
   if (bucket != EOF)
     return true;
 
-#if defined(__SAM3X8E__)
+#if defined(__SAM3X8E__) or defined(ARDUINO_ARCH_STM32F1)
   while ((ch!=EOF) && (offset<32000))  ///fix it
 #else
   while (addr+offset<EEPROM.length())

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -144,7 +144,7 @@ aJsonEEPROMStream::available()
   if (bucket != EOF)
     return true;
 
-#if defined(__SAM3X8E__) or defined(ARDUINO_ARCH_STM32F1) or defined (NRF5) or defined (ARDUINO_ARCH_ESP32) or defined (ARDUINO_ARCH_STM32)
+#if defined(__SAM3X8E__) or defined(ARDUINO_ARCH_STM32) or defined (NRF5) or defined (ARDUINO_ARCH_ESP32) or defined (ARDUINO_ARCH_STM32)
   while ((ch!=EOF) && (offset<32000))  ///fix it
 #else
   while (addr+offset<EEPROM.length())
@@ -177,10 +177,10 @@ int aJsonEEPROMStream::putEOF(void)
        res = write(EOF);
        #if defined(ARDUINO_ARCH_ESP8266)
          // write the data to EEPROM
-       res  = EEPROM.commit();
+       res  = EEPROM.commitReset();
+       Serial.println((res) ? "Commit OK" : "Commit failed");
        #endif.
-       //Serial.println((res) ? "Commit OK" : "Commit failed");
-       return res;
+        return res;
        }
 
 size_t

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -142,7 +142,7 @@ aJsonEEPROMStream::available()
   if (bucket != EOF)
     return true;
 
-#if defined(__SAM3X8E__) or defined(ARDUINO_ARCH_STM32F1)
+#if defined(__SAM3X8E__) or defined(ARDUINO_ARCH_STM32F1) or defined (NRF5)
   while ((ch!=EOF) && (offset<32000))  ///fix it
 #else
   while (addr+offset<EEPROM.length())

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -49,6 +49,9 @@
 #if defined(__SAM3X8E__)
 #include <DueFlashStorage.h>
 extern DueFlashStorage EEPROM;
+#elif defined(NRF5)
+#include <NRFFlashStorage.h>
+extern NRFFlashStorage EEPROM;
 #else
 #include <EEPROM.h>
 #endif

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -46,19 +46,7 @@
 #include "aJSON.h"
 #include "utility/stringbuffer.h"
 #include <stdio.h>
-/*
-#if defined(__SAM3X8E__)
-#include <DueFlashStorage.h>
-extern DueFlashStorage EEPROM;
-#elif defined(NRF5) || defined (ARDUINO_ARCH_ESP32) || defined (ARDUINO_ARCH_STM32)
-#include <NRFFlashStorage.h>
-extern NRFFlashStorage EEPROM;
-#elif defined(ARDUINO_ARCH_ESP8266)
-#include <ESP_EEPROM.h>
-#else
-#include <EEPROM.h>
-#endif
-*/
+
 /******************************************************************************
  * Definitions
  ******************************************************************************/
@@ -125,65 +113,6 @@ aJsonFileStream::getch()
   return fgetc(fl);
 }
 
-/*
-int
-aJsonEEPROMStream::getch()
-{ char c;
-  if (bucket != EOF)
-    {
-      int ret = bucket;
-      bucket = EOF;
-      return ret;
-    }
-    c=EEPROM.read(addr+offset++);
-  return c;
-}
-
-bool
-aJsonEEPROMStream::available()
-{
-  int ch =0;
-  if (bucket != EOF)
-    return true;
-
-#if defined(__SAM3X8E__) or defined(ARDUINO_ARCH_STM32) or defined (NRF5) or defined (ARDUINO_ARCH_ESP32) or defined (ARDUINO_ARCH_STM32)
-  while ((ch!=EOF) && (offset<32000))  ///fix it
-#else
-  while (addr+offset<EEPROM.length())
-#endif    
-
-    {
-      ch = this->getch();
-      
-      if (ch > 32)
-       {
-         this->ungetch(ch);
-         return true;
-       }
-    }
-  return false;
-  }    
-
-
-size_t
-aJsonEEPROMStream::write(uint8_t ch)
-{
-EEPROM.write(addr+offset++,(char)ch);
-return 1;
-}
-
-int aJsonEEPROMStream::putEOF(void)
-       {
-       int res;
-       res = write(EOF);
-       #if defined(ARDUINO_ARCH_ESP8266)
-         // write the data to EEPROM
-       res  = EEPROM.commitReset();
-       Serial.println((res) ? "Commit OK" : "Commit failed");
-       #endif.
-        return res;
-       }
-*/
 
 size_t
 aJsonStream::write(uint8_t ch)
@@ -277,6 +206,7 @@ aJsonClass::newItem()
 void
 aJsonClass::deleteItem(aJsonObject *c)
 {
+  if (!c) return;  
   aJsonObject *next;
   while (c)
     {
@@ -1013,6 +943,7 @@ aJsonStream::printObject(aJsonObject *item)
 unsigned char
 aJsonClass::getArraySize(aJsonObject *array)
 {
+  if (!array) return 0;
   aJsonObject *c = array->child;
   unsigned char i = 0;
   while (c)
@@ -1022,6 +953,7 @@ aJsonClass::getArraySize(aJsonObject *array)
 aJsonObject*
 aJsonClass::getArrayItem(aJsonObject *array, unsigned char item)
 {
+  if (!array) return NULL;
   aJsonObject *c = array->child;
   while (c && item > 0)
     item--, c = c->next;
@@ -1030,6 +962,7 @@ aJsonClass::getArrayItem(aJsonObject *array, unsigned char item)
 aJsonObject*
 aJsonClass::getObjectItem(aJsonObject *object, const char *string)
 {
+  if (!object) return NULL;
   aJsonObject *c = object->child;
   while (c && strcasecmp(c->name, string))
     c = c->next;
@@ -1061,6 +994,7 @@ aJsonClass::createReference(aJsonObject *item)
 void
 aJsonClass::addItemToArray(aJsonObject *array, aJsonObject *item)
 {
+  if (!array) return;
   aJsonObject *c = array->child;
   if (!item)
     return;
@@ -1101,6 +1035,7 @@ aJsonClass::addItemReferenceToObject(aJsonObject *object, const char *string,
 aJsonObject*
 aJsonClass::detachItemFromArray(aJsonObject *array, unsigned char which)
 {
+  if (!array) return NULL;
   aJsonObject *c = array->child;
   while (c && which > 0)
     c = c->next, which--;
@@ -1124,6 +1059,7 @@ aJsonObject*
 aJsonClass::detachItemFromObject(aJsonObject *object, const char *string)
 {
   unsigned char i = 0;
+  if (!object) return NULL;
   aJsonObject *c = object->child;
   while (c && strcasecmp(c->name, string))
     i++, c = c->next;
@@ -1142,6 +1078,7 @@ void
 aJsonClass::replaceItemInArray(aJsonObject *array, unsigned char which,
     aJsonObject *newitem)
 {
+  if (!array) return;
   aJsonObject *c = array->child;
   while (c && which > 0)
     c = c->next, which--;

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -49,7 +49,7 @@
 #if defined(__SAM3X8E__)
 #include <DueFlashStorage.h>
 extern DueFlashStorage EEPROM;
-#elif defined(NRF5) || defined (ARDUINO_ARCH_ESP32)
+#elif defined(NRF5) || defined (ARDUINO_ARCH_ESP32) || defined (ARDUINO_ARCH_STM32)
 #include <NRFFlashStorage.h>
 extern NRFFlashStorage EEPROM;
 #elif defined(ARDUINO_ARCH_ESP8266)
@@ -144,7 +144,7 @@ aJsonEEPROMStream::available()
   if (bucket != EOF)
     return true;
 
-#if defined(__SAM3X8E__) or defined(ARDUINO_ARCH_STM32F1) or defined (NRF5) or defined (ARDUINO_ARCH_ESP32)
+#if defined(__SAM3X8E__) or defined(ARDUINO_ARCH_STM32F1) or defined (NRF5) or defined (ARDUINO_ARCH_ESP32) or defined (ARDUINO_ARCH_STM32)
   while ((ch!=EOF) && (offset<32000))  ///fix it
 #else
   while (addr+offset<EEPROM.length())

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -217,11 +217,11 @@ aJsonClass::deleteItem(aJsonObject *c)
         }
       if ((c->type == aJson_String) && c->valuestring)
         {
-          free(c->valuestring);
+          freeString(c->valuestring);
         }
       if (c->name)
         {
-          free(c->name);
+          freeString(c->name);
         }
       free(c);
       c = next;
@@ -1016,8 +1016,8 @@ aJsonClass::addItemToObject(aJsonObject *object, const char *string,
   if (!item)
     return;
   if (item->name)
-    free(item->name);
-  item->name = strdup(string);
+    freeString(item->name);
+  item->name = newString(string);
   addItemToArray(object, item);
 }
 void
@@ -1105,7 +1105,7 @@ aJsonClass::replaceItemInObject(aJsonObject *object, const char *string,
     i++, c = c->next;
   if (c)
     {
-      newitem->name = strdup(string);
+      newitem->name = newString(string);
       replaceItemInArray(object, i, newitem);
     }
 }
@@ -1175,7 +1175,8 @@ aJsonClass::createItem(const char *string)
   if (item)
     {
       item->type = aJson_String;
-      item->valuestring = strdup(string);
+     /// item->valuestring = strdup(string);
+     item->valuestring = newString(string);
     }
   return item;
 }
@@ -1298,5 +1299,7 @@ aJsonClass::addStringToObject(aJsonObject* object, const char* name,
 }
 
 //TODO conversion routines btw. float & int types?
+void debugPrint(const char* s){Serial.print(s);}
 
 aJsonClass aJson;
+

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -46,6 +46,7 @@
 #include "aJSON.h"
 #include "utility/stringbuffer.h"
 #include <stdio.h>
+/*
 #if defined(__SAM3X8E__)
 #include <DueFlashStorage.h>
 extern DueFlashStorage EEPROM;
@@ -57,6 +58,7 @@ extern NRFFlashStorage EEPROM;
 #else
 #include <EEPROM.h>
 #endif
+*/
 /******************************************************************************
  * Definitions
  ******************************************************************************/
@@ -123,7 +125,7 @@ aJsonFileStream::getch()
   return fgetc(fl);
 }
 
-
+/*
 int
 aJsonEEPROMStream::getch()
 { char c;
@@ -151,7 +153,6 @@ aJsonEEPROMStream::available()
 #endif    
 
     {
-      /* Make an effort to skip whitespace. */
       ch = this->getch();
       
       if (ch > 32)
@@ -182,6 +183,7 @@ int aJsonEEPROMStream::putEOF(void)
        #endif.
         return res;
        }
+*/
 
 size_t
 aJsonStream::write(uint8_t ch)

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -719,6 +719,7 @@ aJsonStream::printValue(aJsonObject *item, bool print_hidden)
     }
     break;
   case aJson_Int:
+  case aJson_Reserved:
     result = this->printInt(item);
     break;
   case aJson_Float:

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -593,7 +593,7 @@ aJsonClass::print(aJsonObject* item, aJsonStream* stream, bool print_hidden)
 }
 
 char*
-aJsonClass::print(aJsonObject* item, bool print_hidden)
+aJsonClass::print(aJsonObject* item)
 {
   char* outBuf = (char*) malloc(PRINT_BUFFER_LEN); /* XXX: Dynamic size. */
   if (outBuf == NULL)
@@ -601,7 +601,7 @@ aJsonClass::print(aJsonObject* item, bool print_hidden)
       return NULL;
     }
   aJsonStringStream stringStream(NULL, outBuf, PRINT_BUFFER_LEN);
-  print(item, &stringStream, print_hidden);
+  print(item, &stringStream);
   return outBuf;
 }
 

--- a/aJSON.h
+++ b/aJSON.h
@@ -42,7 +42,8 @@
 #define aJson_Array 5
 #define aJson_Object 6
 
-#define aJson_IsReference 128
+////#define aJson_IsReference 128
+#define aJson_IsReference 8
 
 #ifndef EOF
 #define EOF -1
@@ -56,8 +57,8 @@ typedef struct aJsonObject {
 	struct aJsonObject *next, *prev; // next/prev allow you to walk array/object chains. Alternatively, use GetArraySize/GetArrayItem/GetObjectItem
 	struct aJsonObject *child; // An array or object item will have a child pointer pointing to a chain of the items in the array/object.
 
-	char type; // The type of the item, as above.
-
+	char type:4; // The type of the item, as above.
+        char subtype:4; // User defined field 
 	union {
 		char *valuestring; // The item's string, if type==aJson_String
 		char valuebool; //the items value for true & false

--- a/aJSON.h
+++ b/aJSON.h
@@ -235,14 +235,14 @@ public:
 	aJsonObject* createNull();
 	aJsonObject* createItem(bool b);
 	aJsonObject* createItem(char b);
-	aJsonObject* createItem(int num);
+	aJsonObject* createItem(long int num);
 	aJsonObject* createItem(double num);
 	aJsonObject* createItem(const char *string);
 	aJsonObject* createArray();
 	aJsonObject* createObject();
 
 	// These utilities create an Array of count items.
-	aJsonObject* createIntArray(int *numbers, unsigned char count);
+	aJsonObject* createIntArray(long int *numbers, unsigned char count);
 	aJsonObject* createFloatArray(double *numbers, unsigned char count);
 	aJsonObject* createDoubleArray(double *numbers, unsigned char count);
 	aJsonObject* createStringArray(const char **strings, unsigned char count);
@@ -270,7 +270,7 @@ public:
 
 	void addNullToObject(aJsonObject* object, const char* name);
 	void addBooleanToObject(aJsonObject* object, const char* name, bool b);
-	void addNumberToObject(aJsonObject* object, const char* name, int n);
+	void addNumberToObject(aJsonObject* object, const char* name, long int n);
         void addNumberToObject(aJsonObject* object, const char* name, double n);
 	void addStringToObject(aJsonObject* object, const char* name,
 					const char* s);

--- a/aJSON.h
+++ b/aJSON.h
@@ -190,10 +190,7 @@ public:
                 offset=0;
         }
        
-       int putEOF(void)
-       {
-       return write(EOF);
-       }
+        int putEOF(void);
 	virtual bool available();
 
 private:

--- a/aJSON.h
+++ b/aJSON.h
@@ -44,7 +44,7 @@
 
 
 ////#define aJson_IsReference 128
-#define aJson_IsReference 8
+#define aJson_IsReference 7
 
 #ifndef EOF
 #define EOF -1
@@ -54,12 +54,12 @@
 
 // The aJson structure:
 typedef struct aJsonObject {
-        char *name; // The item's name string, if this item is the child of, or is in the list of subitems of an object.
+    char *name; // The item's name string, if this item is the child of, or is in the list of subitems of an object.
 	struct aJsonObject *next, *prev; // next/prev allow you to walk array/object chains. Alternatively, use GetArraySize/GetArrayItem/GetObjectItem
 	struct aJsonObject *child; // An array or object item will have a child pointer pointing to a chain of the items in the array/object.
 
-	char type:4; // The type of the item, as above.
-        char subtype:4; // User defined field 
+	unsigned char type:3; // The type of the item, as above.
+    unsigned char subtype:5; // User defined field 
 	union {
 		char *valuestring; // The item's string, if type==aJson_String
 		char valuebool; //the items value for true & false

--- a/aJSON.h
+++ b/aJSON.h
@@ -183,28 +183,6 @@ private:
         virtual int getch();
         FILE* fl;
 };
-/*
-class aJsonEEPROMStream : public aJsonStream {
-public:
-        aJsonEEPROMStream(int _addr)
-                : aJsonStream(NULL)
-        {
-                addr=_addr;
-                offset=0;
-        }
-       
-        int putEOF(void);
-	virtual bool available();
-
-private:
-        virtual int getch();
-        virtual size_t write(uint8_t ch);
-
-        int addr;
-        int offset;
-};
-
-*/
 
 class aJsonClass {
 	/******************************************************************************

--- a/aJSON.h
+++ b/aJSON.h
@@ -167,6 +167,20 @@ private:
 	size_t inbuf_len, outbuf_len;
 };
 
+class aJsonFileStream : public aJsonStream {
+public:
+        aJsonFileStream(FILE* _fl)
+                : aJsonStream(NULL)
+        {
+                fl=_fl;
+        }
+
+
+private:
+        virtual int getch();
+        FILE* fl;
+};
+
 class aJsonClass {
 	/******************************************************************************
 	 * Constructors

--- a/aJSON.h
+++ b/aJSON.h
@@ -181,7 +181,7 @@ private:
         virtual int getch();
         FILE* fl;
 };
-
+/*
 class aJsonEEPROMStream : public aJsonStream {
 public:
         aJsonEEPROMStream(int _addr)
@@ -202,6 +202,7 @@ private:
         int offset;
 };
 
+*/
 
 class aJsonClass {
 	/******************************************************************************

--- a/aJSON.h
+++ b/aJSON.h
@@ -41,10 +41,11 @@
 #define aJson_String 4
 #define aJson_Array 5
 #define aJson_Object 6
+#define aJson_Reserved 7
 
 
 ////#define aJson_IsReference 128
-#define aJson_IsReference 7
+#define aJson_IsReference 8
 
 #ifndef EOF
 #define EOF -1
@@ -58,8 +59,8 @@ typedef struct aJsonObject {
 	struct aJsonObject *next, *prev; // next/prev allow you to walk array/object chains. Alternatively, use GetArraySize/GetArrayItem/GetObjectItem
 	struct aJsonObject *child; // An array or object item will have a child pointer pointing to a chain of the items in the array/object.
 
-	unsigned char type:3; // The type of the item, as above.
-    unsigned char subtype:5; // User defined field 
+	unsigned char type:4; // The type of the item, as above.
+    unsigned char subtype:4; // User defined field 
 	union {
 		char *valuestring; // The item's string, if type==aJson_String
 		char valuebool; //the items value for true & false

--- a/aJSON.h
+++ b/aJSON.h
@@ -181,6 +181,30 @@ private:
         FILE* fl;
 };
 
+class aJsonEEPROMStream : public aJsonStream {
+public:
+        aJsonEEPROMStream(int _addr)
+                : aJsonStream(NULL)
+        {
+                addr=_addr;
+                offset=0;
+        }
+       
+       int putEOF(void)
+       {
+       return write(EOF);
+       }
+	virtual bool available();
+
+private:
+        virtual int getch();
+        virtual size_t write(uint8_t ch);
+
+        int addr;
+        int offset;
+};
+
+
 class aJsonClass {
 	/******************************************************************************
 	 * Constructors

--- a/aJSON.h
+++ b/aJSON.h
@@ -61,8 +61,8 @@ typedef struct aJsonObject {
 	union {
 		char *valuestring; // The item's string, if type==aJson_String
 		char valuebool; //the items value for true & false
-		int valueint; // The item's value, if type==aJson_Int
-		double valuefloat; // The item's value, if type==aJson_Float
+		long int valueint; // The item's value, if type==aJson_Int
+		float valuefloat; // The item's value, if type==aJson_Float
 	};
 } aJsonObject;
 
@@ -89,7 +89,7 @@ public:
 	int printString(aJsonObject *item);
 
 	int skip();
-	int flush();
+	void flush();
 
 	int parseValue(aJsonObject *item, char** filter);
 	int printValue(aJsonObject *item);

--- a/aJSON.h
+++ b/aJSON.h
@@ -42,6 +42,7 @@
 #define aJson_Array 5
 #define aJson_Object 6
 
+
 ////#define aJson_IsReference 128
 #define aJson_IsReference 8
 
@@ -288,4 +289,12 @@ private:
 
 extern aJsonClass aJson;
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+void debugPrint(const char* s);
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/aJSON.h
+++ b/aJSON.h
@@ -95,13 +95,13 @@ public:
 	void flush();
 
 	int parseValue(aJsonObject *item, char** filter);
-	int printValue(aJsonObject *item);
+	int printValue(aJsonObject *item, bool print_hidden = true);
 
 	int parseArray(aJsonObject *item, char** filter);
-	int printArray(aJsonObject *item);
+	int printArray(aJsonObject *item, bool print_hidden = true);
 
 	int parseObject(aJsonObject *item, char** filter);
-	int printObject(aJsonObject *item);
+	int printObject(aJsonObject *item, bool print_hidden = true);
 
 protected:
 	/* Blocking load of character, returning EOF if the stream
@@ -198,8 +198,8 @@ public:
         aJsonObject* parse(aJsonStream* stream,char** filter_values); //Read from a file, but only return values include in the char* array filter_values
 	aJsonObject* parse(char *value); //Reads from a string
 	// Render a aJsonObject entity to text for transfer/storage. Free the char* when finished.
-	int print(aJsonObject *item, aJsonStream* stream);
-	char* print(aJsonObject* item);
+	int print(aJsonObject *item, aJsonStream* stream, bool print_hidden = true);
+	char* print(aJsonObject* item , bool print_hidden = true);
 	//Renders a aJsonObject directly to a output stream
 	char stream(aJsonObject *item, aJsonStream* stream);
 	// Delete a aJsonObject entity and all sub-entities.

--- a/aJSON.h
+++ b/aJSON.h
@@ -198,8 +198,8 @@ public:
         aJsonObject* parse(aJsonStream* stream,char** filter_values); //Read from a file, but only return values include in the char* array filter_values
 	aJsonObject* parse(char *value); //Reads from a string
 	// Render a aJsonObject entity to text for transfer/storage. Free the char* when finished.
-	int print(aJsonObject *item, aJsonStream* stream, bool print_hidden = true);
-	char* print(aJsonObject* item , bool print_hidden = true);
+	int print(aJsonObject *item, aJsonStream* stream, bool print_hidden=true);
+	char* print(aJsonObject* item);
 	//Renders a aJsonObject directly to a output stream
 	char stream(aJsonObject *item, aJsonStream* stream);
 	// Delete a aJsonObject entity and all sub-entities.

--- a/sam/pgmspace.h
+++ b/sam/pgmspace.h
@@ -1,0 +1,38 @@
+#ifndef __PGMSPACE_H_
+#define __PGMSPACE_H_ 1
+
+#include <inttypes.h>
+
+#define PROGMEM
+#define PGM_P  const char *
+#define PSTR(str) (str)
+
+typedef void prog_void;
+typedef char prog_char;
+typedef unsigned char prog_uchar;
+typedef int8_t prog_int8_t;
+typedef uint8_t prog_uint8_t;
+typedef int16_t prog_int16_t;
+typedef uint16_t prog_uint16_t;
+typedef int32_t prog_int32_t;
+typedef uint32_t prog_uint32_t;
+
+#define strcpy_P(dest, src) strcpy((dest), (src))
+#define strcat_P(dest, src) strcat((dest), (src))
+#define strcmp_P(a, b) strcmp((a), (b))
+
+#define pgm_read_byte(addr) (*(const unsigned char *)(addr))
+#define pgm_read_word(addr) (*(const unsigned short *)(addr))
+#define pgm_read_dword(addr) (*(const unsigned long *)(addr))
+#define pgm_read_float(addr) (*(const float *)(addr))
+
+#define pgm_read_byte_near(addr) pgm_read_byte(addr)
+#define pgm_read_word_near(addr) pgm_read_word(addr)
+#define pgm_read_dword_near(addr) pgm_read_dword(addr)
+#define pgm_read_float_near(addr) pgm_read_float(addr)
+#define pgm_read_byte_far(addr) pgm_read_byte(addr)
+#define pgm_read_word_far(addr) pgm_read_word(addr)
+#define pgm_read_dword_far(addr) pgm_read_dword(addr)
+#define pgm_read_float_far(addr) pgm_read_float(addr)
+
+#endif

--- a/utility/stringbuffer.c
+++ b/utility/stringbuffer.c
@@ -26,7 +26,11 @@
 #include "stringbuffer.h"
 
 //Default buffer size for strings
+#if defined(ARDUINO_ARCH_AVR)
+#define BUFFER_SIZE 64
+#else
 #define BUFFER_SIZE 256
+#endif
 //there is a static buffer allocated, which is used to decode strings to
 //strings cannot be longer than the buffer
 char global_buffer[BUFFER_SIZE];

--- a/utility/stringbuffer.c
+++ b/utility/stringbuffer.c
@@ -62,7 +62,7 @@ stringBufferCreate(void)
 char
 stringBufferAdd(char value, string_buffer* buffer)
 {
-  if (buffer->string_length >= buffer->memory)
+  if (buffer->string_length >= buffer->memory-1)
     {
       //this has to be enabled after realloc works
       /*char* new_string = (char*) realloc((void*) buffer->string, (buffer->memory
@@ -108,6 +108,7 @@ stringBufferToString(string_buffer* buffer)
   char * result = newString(global_buffer);
   if (result == NULL)
     {
+     // debugPrint(("String allocation error\n")); 
       return NULL;
     }
 
@@ -158,7 +159,7 @@ static string_card stringLib ={NULL,0,NULL};
      string_card * prevCard;
      if (card) 
               { 
-            //    debugPrint(":reused; ");
+                //debugPrint(":reused; ");
                 card->used++;
                 return card->string;
               }
@@ -171,7 +172,7 @@ static string_card stringLib ={NULL,0,NULL};
                             {
                               card->string = strdup(str);
                               card->used=1;
-              //                debugPrint(":added/replaced; ");
+                              //debugPrint(":added/replaced; ");
                               return card->string;
                             }
                 prevCard = card;             
@@ -185,7 +186,7 @@ static string_card stringLib ={NULL,0,NULL};
                     card->string = strdup(str);
                     card->used=1;
                     card->next=NULL;
-   //                 debugPrint(":added ");
+                    //debugPrint(":added ");
                     return card->string;  
                 }            
               }
@@ -199,10 +200,10 @@ static string_card stringLib ={NULL,0,NULL};
     card->used--;
     if (!card->used) 
                         {
-                 //       debugPrint(str);  
+                        //debugPrint(str);  
                         free(card->string);
                         card->string = NULL;
-                //        debugPrint(":removed ");
+                        //debugPrint(":removed ");
                         compressList();
                         }
   } 
@@ -226,4 +227,5 @@ static string_card stringLib ={NULL,0,NULL};
           nextPtr=nextPtr->next;      
           }
   }
+  //debugPrint(("Compressed\n")); 
   }

--- a/utility/stringbuffer.h
+++ b/utility/stringbuffer.h
@@ -24,7 +24,7 @@
 
 #ifndef STRINGBUFFER_H_
 #define STRINGBUFFER_H_
-
+#include <Arduino.h>
 typedef struct
 {
   char* string;
@@ -32,11 +32,12 @@ typedef struct
   unsigned int string_length;
 } string_buffer;
 
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif
-
+extern void debugPrint(const char*);
   string_buffer*
   stringBufferCreate(void);
 
@@ -49,7 +50,24 @@ extern "C"
   void
   stringBufferFree(string_buffer* buffer);
 
+typedef struct string_card string_card;
+struct string_card
+{
+  char* string;
+  uint8_t used;
+  string_card * next;
+};
+
+  
+
+  string_card *findString(char *);
+  char *newString(const char *);
+  void  freeString(char *); 
+  void compressList();
+
+
 #ifdef __cplusplus
 }
 #endif
+
 #endif /* STRINGBUFFER_H_ */


### PR DESCRIPTION
adding class "aJsonFileStream" inherited from aJsonStream in order to backward- compatibility with HTTPClient library
Now is possible to operate directly with *FILE like streams, returned by HttpClient library and avoid intermediate buffering

Code example:

```

int getConfig()
{
    FILE* result;
    int returnCode ;

    HTTPClient hclient("192.168.88.2",hserver,80);
    result = hclient.getURI( FEED_URI);
    returnCode = hclient.getLastReturnCode();

    if (result!=NULL) {
      if (returnCode==200) {

          Serial.println("got Config :"); 
             aJsonFileStream as=aJsonFileStream(result);  
          root = aJson.parse(&as);

     hclient.closeStream(result);  // this is very important -- be sure to close the STREAM

        if (!root)
          {
            Serial.println("parseObject() failed");
           return -11;
            } else   

          {

            char * outstr=aJson.print(root);
            Serial.println(outstr);
             items = aJson.getObjectItem(root,"items");            
          }

            } 
    else {
      Serial.print("ERROR: Server returned ");
      Serial.println(returnCode);
      return -11;

    }

    } 
    else {
      Serial.println("failed to connect");
      Serial.println(" try again in 5 seconds");
      return -11;
                }



  return 2;
}

```
