### PR TITLE
Improve performance for high-overhead clients

### DIFF
--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -432,7 +432,7 @@ aJsonStream::parseString(aJsonObject *item)
 int
 aJsonStream::printStringPtr(const char *str)
 {
-  this->print("\"");
+  this->print('"');
   char* ptr = (char*) str;
   if (ptr != NULL)
     {

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -434,7 +434,7 @@ aJsonStream::printStringPtr(const char *str)
 {
   this->print('"');
   char* ptr = (char*) str;
-  if (ptr != NULL)
+  if (ptr != NULL && *ptr != '\0')
     {
       while (*ptr != 0)
         {

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -442,6 +442,26 @@ aJsonStream::printStringPtr(const char *str)
   char* ptr = (char*) str;
   if (ptr != NULL && *ptr != '\0')
     {
+      char* check = ptr;
+      bool hasEscapes = false;
+      while (*check != 0)
+        {
+          if ((unsigned char) *check > 31 && *check != '\"' && *check != '\\')
+            {
+            }
+          else
+            {
+              hasEscapes = true;
+              break;
+            }
+          check++;
+        }
+      if (!hasEscapes)
+        {
+          this->print(ptr);
+          this->print('\"');
+          return 0;
+        }
       while (*ptr != 0)
         {
           if ((unsigned char) *ptr > 31 && *ptr != '\"' && *ptr != '\\')

--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -103,6 +103,12 @@ aJsonStream::write(uint8_t ch)
 }
 
 size_t
+aJsonStream::write(const uint8_t *str, size_t len)
+{
+  return stream()->write(str, len);
+}
+
+size_t
 aJsonStream::readBytes(uint8_t *buffer, size_t len)
 {
   for (size_t i = 0; i < len; i++)

--- a/aJSON.h
+++ b/aJSON.h
@@ -114,6 +114,7 @@ protected:
 
 	/* Inherited from class Print. */
 	virtual size_t write(uint8_t ch);
+	virtual size_t write(const uint8_t *str, size_t len);
 
 	/* stream attribute is used only from virtual functions,
 	 * therefore an object inheriting aJsonStream may avoid


### PR DESCRIPTION
While trying to write a printer to render objects directly to a web stream, I encountered these performance issues. Rendering time went from >1.5s to <0.4s with these changes due to reduction in the number of calls into the web client interface.