### PR TITLE
fix spurious void/int flush() override

### DIFF
--- a/aJSON.cpp
+++ b/aJSON.cpp
@@ -510,7 +510,7 @@ aJsonStream::skip()
 // Utility to flush our buffer in case it contains garbage
 // since the parser will return the buffer untouched if it
 // cannot understand it.
-int
+void
 aJsonStream::flush()
 {
   int in = this->getch();
@@ -518,7 +518,7 @@ aJsonStream::flush()
   {
     in = this->getch();
   }
-  return EOF;
+  return;
 }
 
 

--- a/aJSON.h
+++ b/aJSON.h
@@ -89,7 +89,7 @@ public:
 	int printString(aJsonObject *item);
 
 	int skip();
-	int flush();
+	void flush();
 
 	int parseValue(aJsonObject *item, char** filter);
 	int printValue(aJsonObject *item);


### PR DESCRIPTION
I can't see any reason to have this return type prevent any further use of this library.  

If you're checking for EOF on a flush() of the stream, please re-consider the reason for it.